### PR TITLE
UPS-3911 - Add balies.cityName.keyword to default search fields

### DIFF
--- a/src/uitpas/search/UiTElasticSearchKit.js
+++ b/src/uitpas/search/UiTElasticSearchKit.js
@@ -122,6 +122,7 @@ export default class UiTElasticSearchKit {
     return [
       "balies.name",
       "balies.cityName",
+      "balies.cityName.keyword",
       "balies.cityZip",
       "owningCardSystem.name",
       "title",


### PR DESCRIPTION
### Added
- balies.cityName.keyword to default search fields

### Fixed
- Search on "Sint-Pieters-Leeuw" etc.

----
Ticket: https://jira.uitdatabank.be/browse/UPS-3911
